### PR TITLE
Bugfix for strategies used in hydrators with naming strategy

### DIFF
--- a/src/AbstractHydrator.php
+++ b/src/AbstractHydrator.php
@@ -59,6 +59,11 @@ abstract class AbstractHydrator implements
     {
         if (isset($this->strategies[$name])) {
             return $this->strategies[$name];
+        } elseif ($this->hasNamingStrategy() &&
+            ($hydrated = $this->getNamingStrategy()->hydrate($name)) &&
+            isset($this->strategies[$hydrated])
+        ) {
+            return $this->strategies[$hydrated];
         }
 
         if (!isset($this->strategies['*'])) {
@@ -80,8 +85,17 @@ abstract class AbstractHydrator implements
      */
     public function hasStrategy($name)
     {
-        return array_key_exists($name, $this->strategies)
-               || array_key_exists('*', $this->strategies);
+        if (array_key_exists($name, $this->strategies)) {
+            return true;
+        }
+
+        if ($this->hasNamingStrategy() &&
+            array_key_exists($this->getNamingStrategy()->hydrate($name), $this->strategies)
+        ) {
+            return true;
+        }
+
+        return array_key_exists('*', $this->strategies);
     }
 
     /**

--- a/test/HydratorTestTrait.php
+++ b/test/HydratorTestTrait.php
@@ -17,7 +17,7 @@ trait HydratorTestTrait
     {
         $namingStrategy = $this->getMock('Zend\Hydrator\NamingStrategy\NamingStrategyInterface');
         $namingStrategy
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('hydrate')
             ->with($this->anything())
             ->will($this->returnValue('value'))
@@ -25,7 +25,7 @@ trait HydratorTestTrait
 
         $strategy = $this->getMock('Zend\Hydrator\Strategy\StrategyInterface');
         $strategy
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('hydrate')
             ->with($this->anything())
             ->will($this->returnValue('hydrate'))


### PR DESCRIPTION
This would be my suggestion how to fix that issue.
Actually this does not break the unit tests at all.